### PR TITLE
Update MovieObject.m

### DIFF
--- a/software/@MovieObject/MovieObject.m
+++ b/software/@MovieObject/MovieObject.m
@@ -89,6 +89,10 @@ classdef  MovieObject < hgsetget
                     if any(cellfun(@(x)strcmp(x,[class(obj) '.relocate']),{stack.name})),
                         status  = true;
                     end
+            %------ Added by Waddah Moghram on 3/7/2019
+                case {'roiMaskPath_'}
+                    status = true;
+            %%----------------
             end
         end
         


### PR DESCRIPTION
Fixes the following error. 
---------------------------------------------------
Undefined function or variable 'roiPath'. 
Error using MovieObject/checkPropertyValue (line 63)
The roimaskpath has been set previously and cannot be changed!
Error in MovieData/setROIMaskPath (line 360)
            obj.checkPropertyValue('roiMaskPath_', path);
Error in setROIfromForcemap (line 107)
MD.setROIMaskPath(roiPath);
Error in forceFieldCalculationProcessGUI>setROIfromForcemap_Callback (line 359)
    setROIfromForcemap(MD);
Error in gui_mainfcn (line 95)
        feval(varargin{:});
Error in forceFieldCalculationProcessGUI (line 62)
        gui_mainfcn(gui_State, varargin{:});
Error in
matlab.graphics.internal.figfile.FigFile/read>@(hObject,eventdata)forceFieldCalculationProcessGUI('setROIfromForcemap_Callback',hObject,eventdata,guidata(hObject)) 
Error while evaluating UIControl Callback.
-------------------------------------------------------