### PR TITLE
Fix linux <-> windows path relocation issue

### DIFF
--- a/software/relocatePath.m
+++ b/software/relocatePath.m
@@ -69,7 +69,7 @@ end
 if ~ischar(oldPath),return; end
 % Check the old root directory is contained within the old path
 nElements = min(numel(oldPath),numel(oldRootDir));
-if isempty(oldRootDir) && ~strcmp(oldPath(1:nElements),oldRootDir), return; end %changes made to account for empty root directory -Sangyoon Han 160601
+if ~isempty(oldRootDir) && ~strcmp(oldPath(1:nElements),oldRootDir), return; end %changes made to account for empty root directory -Sangyoon Han 160601
 
 
 % Get file separators of old and new root directories as regular


### PR DESCRIPTION
sometimes paths which did not contain the given root dir still made it past line 72; when relocation was attempted, the path wasn't fundamentally changed, BUT in the case of posix/windows relocation, the forwardslashes were changed to backslash. For repeated relocation of multiple folders to different places, this meant all paths not matched by the first relocation were all set to have backslash separators, meaning they are permanently unrelocatable by the subsequent relocations, since they are still looking for backslashes. The conditional that was supposed to detect this was broken, I fixed it